### PR TITLE
Partial export Support

### DIFF
--- a/Reader/Database/ProductModelReader.php
+++ b/Reader/Database/ProductModelReader.php
@@ -8,6 +8,18 @@ class ProductModelReader extends BaseProductModelReader
 {
     protected function getConfiguredFilters()
     {
+        if ($this->stepExecution->getJobExecution()->getJobInstance()->getJobName() === "partial_export") {
+            return [
+                [
+                    "field" => "updated",
+                    "operator" => "SINCE LAST JOB",
+                    "value" => $this->stepExecution
+                        ->getJobExecution()
+                        ->getJobInstance()
+                        ->getCode()
+                ]
+            ];
+        }
         return [];
     }
 }

--- a/Reader/Database/ProductReader.php
+++ b/Reader/Database/ProductReader.php
@@ -2,11 +2,12 @@
 
 namespace Snowio\Bundle\CsvConnectorBundle\Reader\Database;
 
-use Akeneo\Pim\Enrichment\Component\Product\Connector\Reader\Database\ProductReader as BaseProductModelReader;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Reader\Database\ProductReader as BaseProductReader;
 
-class ProductModelReader extends BaseProductModelReader
+class ProductReader extends BaseProductReader
 {
     use UpdatedFilterTrait;
+
     const PARTIAL_EXPORT = "partial_export";
 
     /**
@@ -16,6 +17,7 @@ class ProductModelReader extends BaseProductModelReader
      */
     protected function getConfiguredFilters()
     {
+        $configuredFilters = parent::getConfiguredFilters();
 
         $jobName = $this->stepExecution
             ->getJobExecution()
@@ -23,9 +25,9 @@ class ProductModelReader extends BaseProductModelReader
             ->getJobName();
 
         if ($jobName !== self::PARTIAL_EXPORT) {
-            return [];
+            return $configuredFilters;
         }
 
-        return $this->updateConfiguredFilters([]);
+        return $this->updateConfiguredFilters($configuredFilters);
     }
 }

--- a/Reader/Database/UpdatedFilterTrait.php
+++ b/Reader/Database/UpdatedFilterTrait.php
@@ -1,0 +1,30 @@
+<?php
+namespace Snowio\Bundle\CsvConnectorBundle\Reader\Database;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+
+trait UpdatedFilterTrait
+{
+    /**
+     * Apply filter to configured filters by force
+     * @param array $configuredFilters
+     * @return array
+     * @author Alex Wanyoike <amw@amp.co>
+     */
+    private function updateConfiguredFilters(array $configuredFilters)
+    {
+        $filters = array_filter($configuredFilters, function ($item) {
+            return $item["field"] !== "updated";
+        });
+        return array_merge([
+            [
+                "field" => "updated",
+                "operator" => Operators::SINCE_LAST_JOB,
+                "value" => $this->stepExecution
+                    ->getJobExecution()
+                    ->getJobInstance()
+                    ->getCode()
+            ]
+        ], $filters);
+    }
+}

--- a/Resources/config/form_parameters.yml
+++ b/Resources/config/form_parameters.yml
@@ -4,6 +4,6 @@ services:
         arguments:
             -
                 full_export: snowio-csv-product-export
-                partial_export: snowio-csv-export
+                partial_export: snowio-csv-product-export
         tags:
             - { name: pim_enrich.provider.form, priority: 100 }

--- a/Resources/config/job_constraints.yml
+++ b/Resources/config/job_constraints.yml
@@ -13,8 +13,9 @@ services:
               - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
 
     snowio_connector.job.job_parameters.constraint_collection_provider.partial_export:
-          class: '%snowio_connector.job.job_parameters.constraint_collection_provider.simple.class%'
+          class: '%snowio_connector.job.job_parameters.constraint_collection_provider.product.class%'
           arguments:
+              - '@akeneo_pim_enrichment.job.job_parameters.constraint_collection_provider.simple_csv_export'
               - ['partial_export']
           tags:
               - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/Resources/config/job_defaults.yml
+++ b/Resources/config/job_defaults.yml
@@ -14,8 +14,11 @@ services:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 
     snowio_connector.job.job_parameters.default_values_provider.partial_export:
-        class: '%snowio_connector.job.job_parameters.default_values_provider.simple.class%'
+        class: '%snowio_connector.job.job_parameters.default_values_provider.product.class%'
         arguments:
+            - '@akeneo_pim_enrichment.job.job_parameters.default_values_provider.simple_csv_export'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
             - ['partial_export']
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }

--- a/Resources/config/jobs.yml
+++ b/Resources/config/jobs.yml
@@ -35,6 +35,8 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             -
+                - '@snowio_connector.step.csv_product.export'
+                - '@snowio_connector.step.csv_product_model.export'
                 - '@snowio_connector.step.csv_category.export'
                 - '@snowio_connector.step.csv_attribute.export'
                 - '@snowio_connector.step.csv_attribute_option.export'

--- a/Resources/config/readers.yml
+++ b/Resources/config/readers.yml
@@ -1,7 +1,11 @@
 parameters:
-  snowio_connector.reader.database.product.class: Snowio\Bundle\CsvConnectorBundle\Reader\Database\ProductModelReader
+  snowio_connector.reader.database.product.class: Snowio\Bundle\CsvConnectorBundle\Reader\Database\ProductReader
+  snowio_connector.reader.database.product_model.class: Snowio\Bundle\CsvConnectorBundle\Reader\Database\ProductModelReader
 
 services:
   snowio_connector.reader.database.product_model:
-    class: %snowio_connector.reader.database.product.class%
+    class: %snowio_connector.reader.database.product_model.class%
     parent: pim_connector.reader.database.product_model
+  snowio_connector.reader.database.product:
+    class: %snowio_connector.reader.database.product.class%
+    parent: pim_connector.reader.database.product

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -84,6 +84,7 @@ services:
         parent: 'pim_connector.step.csv_product.export'
         arguments:
             index_0: 'product'
+            index_3: '@snowio_connector.reader.database.product'
             index_5: '@snowio_connector.writer.file.csv_product'
 
     snowio_connector.step.csv_product_model.export:

--- a/Resources/translations/jsmessages.en.yml
+++ b/Resources/translations/jsmessages.en.yml
@@ -34,7 +34,7 @@ snowio_connector.form.job_instance.tab.properties:
 
 batch_jobs:
   partial_export:
-    label: Partial Export (categories, attributes, attribute options, families and attribute groups)
+    label: Partial Export (product updates, product model updates, categories, attributes, attribute options, families and attribute groups)
     category.label:  Category Export Step
     attribute.label: Attribute Export Step
     attribute_option.label: Attribute Option Export Step


### PR DESCRIPTION
## Overview 

This PR aims to add partial export support for products and product exports. It will firstly expose products and product models to the partial export job then update the UI form extensions such that it uses the full export ui controls. Next we override the product and product model database readers such that filter configurations will always add a filter to the updated field iff the job is a partial export.

## Tasks
- [x] Expose export Job
- [x] Update form extensions for job
- [x] Force database readers to filter iff job is a partial export